### PR TITLE
docs: update docs/docs/deploying-to-firebase.md

### DIFF
--- a/docs/docs/deploying-to-firebase.md
+++ b/docs/docs/deploying-to-firebase.md
@@ -47,61 +47,61 @@ In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting
 
 1. Update the `firebase.json` with the following cache settings
 
-    ```json
-    {
-      "hosting": {
-        "public": "public",
-        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-        "headers": [
-          {
-            "source": "**/*",
-            "headers": [
-              {
-                "key": "cache-control",
-                "value": "cache-control: public, max-age=0, must-revalidate"
-              }
-            ]
-          },
-          {
-            "source": "static/**",
-            "headers": [
-              {
-                "key": "cache-control",
-                "value": "public, max-age=31536000, immutable"
-              }
-            ]
-          },
-          {
-            "source": "**/*.@(css|js)",
-            "headers": [
-              {
-                "key": "cache-control",
-                "value": "public, max-age=31536000, immutable"
-              }
-            ]
-          },
-          {
-            "source": "sw.js",
-            "headers": [
-              {
-                "key": "cache-control",
-                "value": "cache-control: public, max-age=0, must-revalidate"
-              }
-            ]
-          },
-          {
-            "source": "page-data/**",
-            "headers": [
-              {
-                "key": "cache-control",
-                "value": "cache-control: public, max-age=0, must-revalidate"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
+   ```json
+   {
+     "hosting": {
+       "public": "public",
+       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+       "headers": [
+         {
+           "source": "**/*",
+           "headers": [
+             {
+               "key": "cache-control",
+               "value": "cache-control: public, max-age=0, must-revalidate"
+             }
+           ]
+         },
+         {
+           "source": "static/**",
+           "headers": [
+             {
+               "key": "cache-control",
+               "value": "public, max-age=31536000, immutable"
+             }
+           ]
+         },
+         {
+           "source": "**/*.@(css|js)",
+           "headers": [
+             {
+               "key": "cache-control",
+               "value": "public, max-age=31536000, immutable"
+             }
+           ]
+         },
+         {
+           "source": "sw.js",
+           "headers": [
+             {
+               "key": "cache-control",
+               "value": "cache-control: public, max-age=0, must-revalidate"
+             }
+           ]
+         },
+         {
+           "source": "page-data/**",
+           "headers": [
+             {
+               "key": "cache-control",
+               "value": "cache-control: public, max-age=0, must-revalidate"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
 
 1. Prepare your site for deployment by running `gatsby build`. This generates a publishable version of your site in the `public` folder.
 

--- a/docs/docs/deploying-to-firebase.md
+++ b/docs/docs/deploying-to-firebase.md
@@ -47,61 +47,61 @@ In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting
 
 1. Update the `firebase.json` with the following cache settings
 
-```json
-{
-  "hosting": {
-    "public": "public",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "headers": [
-      {
-        "source": "**/*",
+    ```json
+    {
+      "hosting": {
+        "public": "public",
+        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
         "headers": [
           {
-            "key": "cache-control",
-            "value": "cache-control: public, max-age=0, must-revalidate"
-          }
-        ]
-      },
-      {
-        "source": "static/**",
-        "headers": [
+            "source": "**/*",
+            "headers": [
+              {
+                "key": "cache-control",
+                "value": "cache-control: public, max-age=0, must-revalidate"
+              }
+            ]
+          },
           {
-            "key": "cache-control",
-            "value": "public, max-age=31536000, immutable"
-          }
-        ]
-      },
-      {
-        "source": "**/*.@(css|js)",
-        "headers": [
+            "source": "static/**",
+            "headers": [
+              {
+                "key": "cache-control",
+                "value": "public, max-age=31536000, immutable"
+              }
+            ]
+          },
           {
-            "key": "cache-control",
-            "value": "public, max-age=31536000, immutable"
-          }
-        ]
-      },
-      {
-        "source": "sw.js",
-        "headers": [
+            "source": "**/*.@(css|js)",
+            "headers": [
+              {
+                "key": "cache-control",
+                "value": "public, max-age=31536000, immutable"
+              }
+            ]
+          },
           {
-            "key": "cache-control",
-            "value": "cache-control: public, max-age=0, must-revalidate"
-          }
-        ]
-      },
-      {
-        "source": "page-data/**",
-        "headers": [
+            "source": "sw.js",
+            "headers": [
+              {
+                "key": "cache-control",
+                "value": "cache-control: public, max-age=0, must-revalidate"
+              }
+            ]
+          },
           {
-            "key": "cache-control",
-            "value": "cache-control: public, max-age=0, must-revalidate"
+            "source": "page-data/**",
+            "headers": [
+              {
+                "key": "cache-control",
+                "value": "cache-control: public, max-age=0, must-revalidate"
+              }
+            ]
           }
         ]
       }
-    ]
-  }
-}
-```
+    }
+    ```
 
 1. Prepare your site for deployment by running `gatsby build`. This generates a publishable version of your site in the `public` folder.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Currently, the list of steps displayed in [Deploying to Firebase](https://www.gatsbyjs.org/docs/deploying-to-firebase/) resets after step 4 [1, 2, 3, 4, 1, 2]. This should put it on the correct order [1, 2, 3, 4, 5, 6]. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
